### PR TITLE
Fix branch name in python semantic release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,25 +7,26 @@ authors = ["Lee Myring <29373851+thinkstack@users.noreply.github.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-pyyaml = "^6.0"
 python-terraform = "^0.10.1"
+pyyaml = "^6.0"
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "^3.3.2"
 bandit = "^1.7.5"
 black = "^23.3.0"
+pre-commit = "^3.3.2"
 pytest = "^7.3.1"
 pytest-black = "^0.3.12"
 pytest-cov = "^4.0.0"
 pytest-pycodestyle = "^2.3.1"
-reorder-python-imports = "^3.9.0"
 python-semantic-release = "^7.33.5"
+reorder-python-imports = "^3.9.0"
 
 [build-system]
 requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.semantic_release]
-version_variable = "pyproject.toml:version"
+branch = "main"
 upload_to_pypi = false
 upload_to_repository = false
+version_variable = "pyproject.toml:version"


### PR DESCRIPTION
What did we do?
--

1. Fix the branch name from `master` -> `main`

