### PR TITLE
Remove ssh signing creds from semver release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,5 +58,3 @@ jobs:
           git_committer_email: ${{ secrets.GIT_COMMITTER_EMAIL }}
           git_committer_name: ${{ secrets.GIT_COMMITTER_NAME }}
           github_token: ${{ secrets.GH_ADMINISTRATOR_TOKEN }}
-          ssh_private_signing_key: ${{ secrets.SSH_PRIVATE_SIGNING_KEY }}
-          ssh_public_signing_key: ${{ secrets.SSH_PUBLIC_SIGNING_KEY }}


### PR DESCRIPTION
- chore: remove commented out code
- feat: remove ssh signing keys from semantic release

What did we do?
--

1.

References
--

1.

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
